### PR TITLE
Fixed ansible lib docs.

### DIFF
--- a/ansible/library/qubesformation.py
+++ b/ansible/library/qubesformation.py
@@ -13,12 +13,13 @@ options:
   dest:
     required: true
     description:
-      - Where to deposit the recipe -- usually a path like
+      - |
+        Where to deposit the recipe -- usually a path like
         `/srv/user_salt/<formation name>.sls`).  Will create
         two files:
-        * The file you specified in `description`.
-        * An additional file with a .top extension instead of the
-          original extension of the file you specified.
+        1. The file you specified in `description`.
+        2. An additional file with a .top extension instead of the
+        original extension of the file you specified.
   others:
     description:
       - All arguments accepted by the M(template) module also work here,

--- a/ansible/library/qubessls.py
+++ b/ansible/library/qubessls.py
@@ -14,7 +14,7 @@ options:
     required: true
     description:
       - The name of the recipe (SLS and top files), as stored in either `/srv/salt` for
-        recipes in the `base` Salt enviornment, or `/srv/user_salt` for those in the `user`
+        recipes in the `base` Salt environment, or `/srv/user_salt` for those in the `user`
         environment.
   env:
     required: false


### PR DESCRIPTION
The formating problem in `ansible/library/qubesformation.py` prevented `ansible-doc qubesformation` to work in Ansible 2.